### PR TITLE
Adding the option '--path-best-match' to storage snmp_standard mode

### DIFF
--- a/snmp_standard/mode/storage.pm
+++ b/snmp_standard/mode/storage.pm
@@ -252,6 +252,7 @@ sub new {
         'storage:s'               => { name => 'storage' },
         'regexp'                  => { name => 'use_regexp' },
         'regexp-isensitive'       => { name => 'use_regexpi' },
+        'path-best-match'         => { name => 'use_path_best_match' },
         'oid-filter:s'            => { name => 'oid_filter', default => 'hrStorageDescr'},
         'oid-display:s'           => { name => 'oid_display', default => 'hrStorageDescr'},
         'display-transform-src:s' => { name => 'display_transform_src' },
@@ -526,6 +527,12 @@ sub get_selection {
         my $name = $self->{statefile_cache}->get(name => $self->{option_results}->{oid_filter} . "_" . $self->{option_results}->{storage});
         push @{$self->{storage_id_selected}}, $self->{option_results}->{storage} if (defined($name) && $self->filter_type(id => $self->{option_results}->{storage}));
     } else {
+        my @path_split = undef;
+	my $path_best_match = undef;
+	my $path_best_match_score = 0;
+	if (defined($self->{option_results}->{use_path_best_match})) {
+	    @path_split = split("/", $self->{option_results}->{storage});
+	}
         foreach my $i (@{$all_ids}) {
             my $filter_name = $self->{statefile_cache}->get(name => $self->{option_results}->{oid_filter} . "_" . $i);
             next if (!defined($filter_name));
@@ -543,6 +550,24 @@ sub get_selection {
             if (!defined($self->{option_results}->{use_regexp}) && !defined($self->{option_results}->{use_regexpi}) && $filter_name eq $self->{option_results}->{storage}) {
                 push @{$self->{storage_id_selected}}, $i if ($self->filter_type(id => $i));
             }
+	    if (defined($self->{option_results}->{use_path_best_match})) {
+		my $path_build = "";
+		my $path_score = 0;
+		foreach my $path_part (@path_split) {
+		    $path_build .= "/" if ( 1 < length($path_build) );
+		    $path_build .= $path_part;
+		    $path_score++;
+		    if ( $path_best_match_score < $path_score && $filter_name =~ /$path_build$/i && ($self->filter_type(id => $i))) {
+			$path_best_match_score = $path_score;
+			$path_best_match = $i;
+		    }
+		    $self->{output}->output_add(long_msg => sprintf("- filter-name [%s] part [%s] build [%s] score [%i] b_score [%i]\n",
+			$filter_name , $path_part,  $path_build , $path_score, $path_best_match_score), debug => 1) if ($self->{output}->is_debug());
+                }
+	    }
+        }
+	if (defined($path_best_match)) {
+	    push @{$self->{storage_id_selected}}, $path_best_match;
         }
     }
     
@@ -615,6 +640,10 @@ Allows to use regexp to filter storage (with option --name).
 =item B<--regexp-isensitive>
 
 Allows to use regexp non case-sensitive (with --regexp).
+
+=item B<--path-best-match>
+
+Allows to select best path mount point (with --name).
 
 =item B<--reload-cache-time>
 


### PR DESCRIPTION
The main idea is the next one: you want to watch /toto/titi .
Depends of the deployment of your system, you might have mounted /toto or /toto/titi .
By using --path-best-match , the path describe in --storage will select the best match mount point.
So, if you have mount /toto on sda1 and /toto/titi on sda2, the result will detect /toto/titi on sda2 .
BUT, if you only mount /toto on sda1 and there is no mount on /toto/titi, the result will detect /toto on sda1 .

What is the interest:
*you can mount /toto with sda1 with 1GB, now you can check if /toto/serviceA have more than 500MB free, and if /toto/serviceB have more than 2GB free ...
*or you can mount /toto with sda1 with 1GB, and /toto/serviceB on sda2 with 5GB, the check will do the job of taking care of the good mount point.